### PR TITLE
Add missing ! to function SlimuxSendCommand

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -193,7 +193,7 @@ command! SlimuxREPLConfigure call SlimuxConfigureCode()
 let s:cmd_packet = { "target_pane": "", "type": "cmd" }
 let s:previous_cmd = ""
 
-function SlimuxSendCommand(cmd)
+function! SlimuxSendCommand(cmd)
 
   let s:previous_cmd = a:cmd
   let s:cmd_packet["text"] = a:cmd . ""


### PR DESCRIPTION
Without this I get a warning every time I source my .vimrc.

Thanks!
