### PR TITLE
Added SlimuxSendKeys function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Prompt for a shell command and send it to configured tmux pane.
 
 ### SlimuxShellLast
 
-Rerun last shell command.
+Rerun last shell command(prompts for a shell command if none was run before).
 
 ### SlimuxShellRun
 
@@ -80,6 +80,30 @@ E.g. to list files with actual asterisks in their name:
 ### SlimuxShellConfigure
 
 Prompt global pane configuration for the shell commands.
+
+
+## Sending Keys
+
+### SlimuxSendKeysPrompt
+
+Prompt for a key sequence using the 'tmux send-keys' syntax and send it to
+a configured tmux pane.
+E.g. Lets say you want to stop the webserver currently running in a
+shell(ctrl+c) and restart it(assuming the command to start is 'make run-server'):
+
+    :SlimuxSendKeysPrompt
+    KEYS>C-C 'make run-server' Enter
+
+In short, some strings such as 'C-C' or 'Enter' have special meanings,
+while others are sent as a sequence of character keys(in the above example, 'make run-server')
+
+### SlimuxSendKeysLast
+
+Resends the last key sequence sent(prompts for a sequence if none was sent before).
+
+### SlimuxSendKeysConfigure
+
+Prompt global pane configuration to send the key sequence.
 
 
 ## Keyboard Shortcuts


### PR DESCRIPTION
This is similar to SlimuxSendCommand, but it is a bit more low level as it doesn't insert carriage return(Enter) automatically and enables sending special keys to the pane(such as ctrl+c for SIGINT).

Also modified SlimuxShellLast so it will prompt for a command if none was sent
before.

I didn't add anything equivalent to the SlimuxShellRun command since if you want to automate a specific key sequence you can just bind it to ':call SlimuxSendKeys' passing the string directly.
