### PR TITLE
Added some code to optionally precompile coffeescript for the Node REPL.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,8 @@ maybe one of these is:
 
 [Python]: https://github.com/epeli/slimux/blob/master/ftplugin/python.vim
 [CoffeeScript]: https://github.com/epeli/slimux/blob/master/ftplugin/coffee.vim
+
+## CoffeeScript Notes
+The original slimux was designed to work with the CoffeeScript REPL.  
+If you prefer the node REPL, just set `let g:SlimuxUseNodeReplForCoffee = 1`
+and the CoffeeScript plugin will precompile snippets for you.

--- a/ftplugin/coffee.vim
+++ b/ftplugin/coffee.vim
@@ -1,16 +1,22 @@
 " CoffeeScript REPL enters multi-line mode with Ctrl+v
 function! SlimuxPre_coffee(target_pane)
+  if !exists('g:SlimuxUseNodeReplForCoffee')
     call system("tmux send-keys -t " . a:target_pane . " C-v")
+  endif
 endfunction
 
 " Exit multi-line REPL mode with Ctrl+d
 function! SlimuxPost_coffee(target_pane)
+  if !exists('g:SlimuxUseNodeReplForCoffee')
     call system("tmux send-keys -t " . a:target_pane . " C-d")
+  endif
 endfunction
 
 " Compile coffee script since the node REPL is far better
 function! SlimuxEscape_coffee(text)
-  let escaped_text = substitute(shellescape(a:text), "\\\\\n", "\n", "g")
-  let l:compiled_text = system("coffee -bep " . escaped_text)
-  return l:compiled_text
+  if exists('g:SlimuxUseNodeReplForCoffee')
+    let escaped_text = substitute(shellescape(a:text), "\\\\\n", "\n", "g")
+    let l:compiled_text = system("coffee -bep " . escaped_text)
+    return l:compiled_text
+  endif
 endfunction


### PR DESCRIPTION
Default behavior is unchanged.  But, if you set a flag (see the bottom of the README) it will precompile the coffeescript into javascript.
