### PR TITLE
support arrow keys in Configure window

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -54,7 +54,7 @@ function! s:SelectPane(tmux_packet)
     belowright new
 
     " Set header for the menu buffer
-    call setline(1, "# Enter: Select pane - Space: Test - Esc/q: Cancel")
+    call setline(1, "# Enter: Select pane - Space: Test - q: Cancel")
     call setline(2, "")
 
     " Add last used pane as the first
@@ -78,9 +78,8 @@ function! s:SelectPane(tmux_packet)
     setlocal nobuflisted nomodifiable noswapfile nowrap
     setlocal cursorline nocursorcolumn
 
-    " Hide buffer on q and <ESC>
+    " Hide buffer on q
     nnoremap <buffer> <silent> q :hide<CR>
-    nnoremap <buffer> <silent> <ESC> :hide<CR>
 
     " Use enter key to pick tmux pane
     nnoremap <buffer> <Enter> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 0)<CR>


### PR DESCRIPTION
Hello,

Please add support for arrow keys (mainly up & down) in the Configure window.

Currently, those keys close the Configure window and insert an alphabet into my buffer.

Thanks for your consideration (and for a *fantastic* Vim plugin!) :v: