### PR TITLE
Small tweaks for the pane list

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -70,7 +70,7 @@ function! s:SelectPane(tmux_packet)
 
     " Put tmux panes in the buffer.
     if !exists("g:slimux_pane_format")
-      let g:slimux_pane_format = '#{session_name}:#{window_index}.#{pane_index}: #{window_name}: #{pane_title} [#{pane_width}x#{pane_height}] #{?pane_active,(active),}'
+      let g:slimux_pane_format = '#{session_name}:#{window_index}.#{pane_index}: #{window_name}: #{pane_title} [#{pane_width}x#{pane_height}]#{?pane_active, (active),}'
     endif
 
     " We need the pane_id at the beginning of the line so we can

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -53,11 +53,11 @@ function! s:SelectPane(tmux_packet)
     " Create new buffer in a horizontal split
     belowright new
 
-    " Get some basic syntax highlighting
-    set filetype=markdown
+    " Use slimux file type
+    set filetype=slimux
 
     " Set header for the menu buffer
-    call setline(1, "# Enter: Select pane - Space: Test - Esc/q: Cancel")
+    call setline(1, "Enter: Select pane - Space: Test - Esc/q: Cancel")
     call setline(2, "")
 
     " Add last used pane as the first

--- a/syntax/slimux.vim
+++ b/syntax/slimux.vim
@@ -1,0 +1,3 @@
+" The first line in the list of panes is the title
+syntax match slimuxPaneListHeading /^.*\%1l.*$/
+highlight def link slimuxPaneListHeading markdownH1


### PR DESCRIPTION
Hi,

I added a syntax file to allow the pane heading to be customisable. It defines a syntax group `slimuxPaneListHeading` that by default is linked to the `markdownH1` syntax group. That will make the current coloring for all users, but now it can be customised using the `slimuxPaneListHeading` syntax group (e.g.: `hi slimuxPaneListHeading ctermfg=red`).

I also made some changes to omit the current pane from the list, as it can mess up the current buffer if you accidentally select the current pane.

The other change was a small annoyance. In the default pane format, there is always a trailing space in the non-active panes, and that triggers the trailing spaces warning that some people have configured. This is illustrated below:

**Before:**
![slimux-trailing-space-1](https://cloud.githubusercontent.com/assets/761254/5428436/7c587bdc-83aa-11e4-81f4-5320ca5e954e.png)

**After:**
![slimux-trailing-space-2](https://cloud.githubusercontent.com/assets/761254/5428438/87ab0f86-83aa-11e4-9ac6-f0959e8a1bf4.png)