### PR TITLE
we get much better syntax highlighting with sh

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -54,7 +54,7 @@ function! s:SelectPane(tmux_packet)
     belowright new
 
     " Get some basic syntax highlighting
-    set filetype=markdown
+    setfiletype sh
 
     " Set header for the menu buffer
     call setline(1, "# Enter: Select pane - Space: Test - Esc/q: Cancel")


### PR DESCRIPTION
Also, setting filetype=markdown brings in heavy prose-related plugins in my Vim config.  I'd like to avoid that overhead when just opening up slimux. :sweat_smile: