### PR TITLE
Fix coffeescript repl post keys

### DIFF
--- a/ftplugin/coffee.vim
+++ b/ftplugin/coffee.vim
@@ -8,5 +8,5 @@ endfunction
 
 " Exit multi-line REPL mode with Ctrl+d
 function! SlimuxPost_coffee(target_pane)
-    call system("tmux send-keys -t " . a:target_pane . " C-d")
+    call system("tmux send-keys -t " . a:target_pane . " C-v")
 endfunction


### PR DESCRIPTION
To exit the multi-line mode of the coffeescript repl one must press 'C-v' in order to do so, 'C-d' will actualy exit the repl.
Here is a comment that mentions this behaviour also https://github.com/purescript/purescript/issues/934#issuecomment-81849080