### PR TITLE
Various improvements in customizability etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Specify a shell command to run directly, without the prompt:
 
 Suitable for mapping and other automation.
 
-Note that you need to double any escapes intended for the shell using this command.
+Note that you need to escape strings intended for the shell.
 E.g. to list files with actual asterisks in their name:
 
-    :SlimuxShellRun ls \\*
+    :SlimuxShellRun ls *\**
 
 ### SlimuxShellConfigure
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -209,8 +209,10 @@ function! s:GetVisual() range
     let reg_save = getreg('"')
     let regtype_save = getregtype('"')
     let cb_save = &clipboard
+
     set clipboard&
     silent normal! ""gvy
+
     let selection = getreg('"')
     call setreg('"', reg_save, regtype_save)
     let &clipboard = cb_save
@@ -223,11 +225,31 @@ function! s:GetBuffer()
     let regtype_save = getregtype('"')
     let cb_save = &clipboard
     set clipboard&
+
     silent normal! ggVGy
     let selection = getreg('"')
+
     call setreg('"', reg_save, regtype_save)
     let &clipboard = cb_save
     call winrestview(l:winview)
+    return selection
+endfunction
+
+function! s:GetParagraph()
+    let reg_save = getreg('"')
+    let regtype_save = getregtype('"')
+    let cb_save = &clipboard
+    set clipboard&
+    let l:l = line(".")
+    let l:c = col(".")
+
+    " Do the business:
+    silent normal ""yip
+    let selection = getreg('"')
+
+    call cursor(l:l, l:c)
+    call setreg('"', reg_save, regtype_save)
+    let &clipboard = cb_save
     return selection
 endfunction
 
@@ -261,25 +283,6 @@ function! s:SlimeSendRange()  range abort
     sil exe a:firstline . ',' . a:lastline . 'yank'
     call SlimuxSendCode(@")
     call setreg('"',rv, rt)
-endfunction
-
-" Pointers taken from the s:Preserve(command) function as shown in
-" http://vimcasts.org/episodes/tidying-whitespace/
-function! s:GetParagraph()
-    " Preparation: save last search, and cursor position.
-    let l:clipboard = getreg('"')
-    let l:l = line(".")
-    let l:c = col(".")
-
-    " Do the business:
-    silent normal ""yip
-    let l:paragraph = getreg('"')
-
-    " Cleanup: restore last cursor position and old clipboard
-    call setreg('"', l:clipboard)
-    call cursor(l:l, l:c)
-
-    return l:paragraph
 endfunction
 
 command! SlimuxREPLSendLine call SlimuxSendCode(getline(".") . "\n")

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -262,8 +262,27 @@ function! s:SlimeSendRange()  range abort
     call setreg('"',rv, rt)
 endfunction
 
+" Pointers taken from the s:Preserve(command) function as shown in
+" http://vimcasts.org/episodes/tidying-whitespace/
+function! s:GetParagraph()
+    " Preparation: save last search, and cursor position.
+    let l:clipboard = getreg('"')
+    let l:l = line(".")
+    let l:c = col(".")
+
+    " Do the business:
+    silent normal ""yip
+    let l:paragraph = getreg('"')
+
+    " Cleanup: restore last cursor position and old clipboard
+    call setreg('"', l:clipboard)
+    call cursor(l:l, l:c)
+
+    return l:paragraph
+endfunction
 
 command! SlimuxREPLSendLine call SlimuxSendCode(getline(".") . "\n")
+command! SlimuxREPLSendParagraph call SlimuxSendCode(s:GetParagraph())
 command! -range=% -bar -nargs=* SlimuxREPLSendSelection call SlimuxSendCode(s:GetVisual())
 command! -range -bar -nargs=0 SlimuxREPLSendLine <line1>,<line2>call s:SlimeSendRange()
 command! -range=% -bar -nargs=* SlimuxREPLSendBuffer call SlimuxSendCode(s:GetBuffer())

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -72,7 +72,7 @@ function! s:SelectPane(tmux_packet)
     let &filetype=g:slimux_buffer_filetype
 
     " Set header for the menu buffer
-    call setline(1, "# Enter: Select pane - Space/x: Test - Esc/q: Cancel")
+    call setline(1, "# Enter: Select pane - Space/x: Test - C-c/q: Cancel")
     call setline(2, "")
 
     " Add last used pane as the first
@@ -115,10 +115,13 @@ function! s:SelectPane(tmux_packet)
     setlocal nobuflisted nomodifiable noswapfile nowrap
     setlocal cursorline nocursorcolumn
 
-    " Hide buffer on q, C-c and <ESC>
+    " Hide buffer on q, and C-c
     nnoremap <buffer> <silent> q :hide<CR>
     nnoremap <buffer> <silent> <C-c> :hide<CR>
-    nnoremap <buffer> <silent> <ESC> :hide<CR>
+
+    if !exists("g:slimux_enable_close_with_esc") && g:slimux_enable_close_with_esc != 0
+        nnoremap <buffer> <silent> <ESC> :hide<CR>
+    endif
 
     " Use enter key to pick tmux pane
     nnoremap <buffer> <silent> <Enter> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 0)<CR>

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -91,7 +91,7 @@ function! s:SelectPane(tmux_packet)
     " We need the pane_id at the beginning of the line so we can
     " identify the selected target pane
     let l:format = '#{pane_id}: ' . g:slimux_pane_format
-    let l:command = "read !tmux list-panes -F '" . escape(l:format, '#') . "'"
+    let l:command = "silent read !tmux list-panes -F '" . escape(l:format, '#') . "'"
 
     " if g:slimux_select_from_current_window = 1, then list panes from current
     " window only.

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -216,6 +216,9 @@ function! s:GetVisual() range
     let selection = getreg('"')
     call setreg('"', reg_save, regtype_save)
     let &clipboard = cb_save
+
+    silent normal! gv
+
     return selection
 endfunction
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -209,16 +209,16 @@ function! s:GetVisual() range
     let reg_save = getreg('"')
     let regtype_save = getregtype('"')
     let cb_save = &clipboard
-
     set clipboard&
-    silent normal! ""gvy
 
+    silent normal! ""gvy
     let selection = getreg('"')
+
+    " restore the selection, this only works if we don't change
+    " pane selection buffer
+    silent normal! gv
     call setreg('"', reg_save, regtype_save)
     let &clipboard = cb_save
-
-    silent normal! gv
-
     return selection
 endfunction
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -72,7 +72,7 @@ function! s:SelectPane(tmux_packet)
     let &filetype=g:slimux_buffer_filetype
 
     " Set header for the menu buffer
-    call setline(1, "# Enter: Select pane - Space: Test - Esc/q: Cancel")
+    call setline(1, "# Enter: Select pane - Space/x: Test - Esc/q: Cancel")
     call setline(2, "")
 
     " Add last used pane as the first
@@ -123,7 +123,8 @@ function! s:SelectPane(tmux_packet)
     " Use enter key to pick tmux pane
     nnoremap <buffer> <silent> <Enter> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 0)<CR>
 
-    nnoremap <buffer> <Space> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 1)<CR>
+    nnoremap <buffer> <silent> x :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 1)<CR>
+    nnoremap <buffer> <silent> <Space> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 1)<CR>
 
     " Set key mapping for pane index hitns
     if !exists("g:slimux_pane_hint_map")

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -38,6 +38,18 @@ function! g:_SlimuxPickPaneFromBuf(tmux_packet, test)
     " Save last selected pane
     let s:last_selected_pane = target_pane
 
+    let type = a:tmux_packet["type"]
+
+    if type == "global"
+        if !exists("b:code_packet")
+            let b:code_packet = { "target_pane": "", "type": "code" }
+        endif
+        let b:code_packet["target_pane"] = a:tmux_packet["target_pane"]
+        let s:cmd_packet["target_pane"] = a:tmux_packet["target_pane"]
+        let s:keys_packet["target_pane"] = a:tmux_packet["target_pane"]
+        return
+    endif
+
     if !empty(s:retry_send)
         call s:Send(s:retry_send)
         let s:retry_send = {}
@@ -306,3 +318,11 @@ endfunction
 command! SlimuxSendKeysPrompt    call SlimuxSendKeys(input('KEYS>', s:previous_keys))
 command! SlimuxSendKeysLast      call SlimuxSendKeys(s:previous_keys != "" ? s:previous_keys : input('KEYS>'))
 command! SlimuxSendKeysConfigure call s:SelectPane(s:keys_packet)
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Global interface (i.e. for repl, shell, and keys )
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+let s:global_conf = { "target_pane": "", "type": "global" }
+
+command! SlimuxGlobalConfigure call s:SelectPane(s:global_conf)

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -113,8 +113,11 @@ function! s:SelectPane(tmux_packet)
 
     nnoremap <buffer> <Space> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 1)<CR>
 
-    " Use d key to display pane index hints
-    nnoremap <buffer> <silent> d :call system("tmux display-panes")<CR>
+    " Set key mapping for pane index hitns
+    if !exists("g:slimux_pane_hint_map")
+      let g:slimux_pane_hint_map = 'dd'
+    endif
+    execute 'nnoremap <buffer> <silent> ' . g:slimux_pane_hint_map . ' :call system("tmux display-panes")<CR>'
 
 endfunction
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -131,7 +131,7 @@ function! s:SelectPane(tmux_packet)
 
     " Set key mapping for pane index hitns
     if !exists("g:slimux_pane_hint_map")
-      let g:slimux_pane_hint_map = 'dd'
+      let g:slimux_pane_hint_map = 'd'
     endif
     execute 'nnoremap <buffer> <silent> ' . g:slimux_pane_hint_map . ' :call system("tmux display-panes")<CR>'
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -121,7 +121,7 @@ function! s:SelectPane(tmux_packet)
     nnoremap <buffer> <silent> <ESC> :hide<CR>
 
     " Use enter key to pick tmux pane
-    nnoremap <buffer> <Enter> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 0)<CR>
+    nnoremap <buffer> <silent> <Enter> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 0)<CR>
 
     nnoremap <buffer> <Space> :call g:_SlimuxPickPaneFromBuf(g:SlimuxActiveConfigure, 1)<CR>
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -315,6 +315,7 @@ function! SlimuxSendKeys(keys)
 
 endfunction
 
+command! -nargs=1 SlimuxSendKeys call SlimuxSendKeys("<args>")
 command! SlimuxSendKeysPrompt    call SlimuxSendKeys(input('KEYS>', s:previous_keys))
 command! SlimuxSendKeysLast      call SlimuxSendKeys(s:previous_keys != "" ? s:previous_keys : input('KEYS>'))
 command! SlimuxSendKeysConfigure call s:SelectPane(s:keys_packet)

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -103,8 +103,9 @@ function! s:SelectPane(tmux_packet)
     setlocal nobuflisted nomodifiable noswapfile nowrap
     setlocal cursorline nocursorcolumn
 
-    " Hide buffer on q and <ESC>
+    " Hide buffer on q, C-c and <ESC>
     nnoremap <buffer> <silent> q :hide<CR>
+    nnoremap <buffer> <silent> <C-c> :hide<CR>
     nnoremap <buffer> <silent> <ESC> :hide<CR>
 
     " Use enter key to pick tmux pane

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -53,8 +53,11 @@ function! s:SelectPane(tmux_packet)
     " Create new buffer in a horizontal split
     belowright new
 
-    " Get some basic syntax highlighting
-    set filetype=markdown
+    " Get syntax highlighting from specified filetype
+    if !exists("g:slimux_buffer_filetype")
+      let g:slimux_buffer_filetype = 'sh'
+    endif
+    let &filetype=g:slimux_buffer_filetype
 
     " Set header for the menu buffer
     call setline(1, "# Enter: Select pane - Space: Test - Esc/q: Cancel")


### PR DESCRIPTION
Hey, here I have some changes to add customizability and some new mappings. I hope they are useful.

- commit 90ff7b2 should read "make config window type customizable via variable", markdown has folds on some setups and 'sh' has already a default good highlight, you can set this to markdown if you want, but the variable adds options to the user.

- I added C-c to hide config buffer, and x to test, <Space> is my leader, so I thought having options would be good
- I also added a hint mapping customization via variable as well.

- the double escaping is no longer needed (?) at least it isn't on my system so I fixed the docs

- Added a command that would propagate a global packet's pane selection to the three individual configs with changes to SelectPane when receiving a packet of type "global"
- Added a command SlimuxSendKeys akin to SlimuxShellRun, that can send arbitrary keys directly from the command line.
- Added a command SlimuxREPLSendParagraph and GetParagraph function to be able to send a paragraph

- Made some stuff silent, as it may be verbose on some vim configurations.