### PR TITLE
GH-51: use stdin instead of brittle split + escape

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -207,18 +207,8 @@ function! s:Send(tmux_packet)
         let text = s:ExecFileTypeFn("SlimuxEscape_", [text])
       endif
 
-
-      " The limit of text bytes tmux can send one time. 500 is a safe value.
-      let s:sent_text_length_limit = 500
-
-      " If the text is too long, split the text into pieces and send them one by one
-      while text != ""
-          let local_text = strpart(text, 0, s:sent_text_length_limit)
-          let text = strpart(text, s:sent_text_length_limit)
-          let local_text = s:EscapeText(local_text)
-          call system("tmux set-buffer -- " . local_text)
-          call system("tmux paste-buffer -t " . target)
-      endwhile
+      call system("tmux load-buffer -", text)
+      call system("tmux paste-buffer -t " . target)
 
       if type == "code"
         call s:ExecFileTypeFn("SlimuxPost_", [target])


### PR DESCRIPTION
This solves issue #51 by passing text from vim to tmux in the standard
input stream in one shot instead of splitting/escaping text in pieces.