### PR TITLE
always use same named buffer to limit memory use

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -207,8 +207,8 @@ function! s:Send(tmux_packet)
         let text = s:ExecFileTypeFn("SlimuxEscape_", [text])
       endif
 
-      call system("tmux load-buffer -", text)
-      call system("tmux paste-buffer -t " . target)
+      call system("tmux load-buffer -b Slimux -", text)
+      call system("tmux paste-buffer -b Slimux -t " . target)
 
       if type == "code"
         call s:ExecFileTypeFn("SlimuxPost_", [target])


### PR DESCRIPTION
This patch makes Slimux always use the same tmux buffer named "Slimux"
to avoid creating a brand new tmux buffer every time we send out text.