### PR TITLE
Add an option to use cpaste for IPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ You can use [Python][] and [CoffeeScript][] hooks as examples.
 - `g:slimux_pane_format` customize the formatting of the panes, see the FORMATS section in `man tmux`.  
   The string "`#{pane_id}: `" is always prepended to the format so Slimux can identify the selected pane.
 
+- `g:slimux_python_ipython = 1` use `%cpaste` of [IPython](http://ipython.org/) to avoid indentation errors. 
+  It is recommended to set this to `1` if you use IPython for an interactive Python session.
+
 
 ## Other Vim Slime plugins
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ You can use [Python][] and [CoffeeScript][] hooks as examples.
   The string "`#{pane_id}: `" is always prepended to the format so Slimux can identify the selected pane.
 
 - `g:slimux_python_ipython = 1` use `%cpaste` of [IPython](http://ipython.org/) to avoid indentation errors. 
-  It is recommended to set this to `1` if you use IPython for an interactive Python session.
+  You need to set this to `1` if you use IPython for an interactive Python session.
 
 
 ## Other Vim Slime plugins

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -3,10 +3,6 @@ let w:slimux_python_allowed_indent0 = ["elif", "else", "except", "finally"]
 
 
 function! SlimuxEscape_python(text)
-  "" Use IPython's '%cpaste' to avoid indentation errors if the option set
-  if exists('g:slimux_python_ipython')
-    return "%cpaste".a:text."--"
-
   "" Check if last line is empty in multiline selections
   let l:last_line_empty = match(a:text,'\n\W*\n$') 
 
@@ -17,6 +13,11 @@ function! SlimuxEscape_python(text)
   "" See if any non-empty lines sent at all
   if no_empty_lines == ""
       return ""
+  endif
+
+  "" Use IPython's '%cpaste' if the option set
+  if exists('g:slimux_python_ipython')
+    return no_empty_lines
   endif
 
   "" Process line by line and insert needed linebreaks

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -3,6 +3,10 @@ let w:slimux_python_allowed_indent0 = ["elif", "else", "except", "finally"]
 
 
 function! SlimuxEscape_python(text)
+  "" Use IPython's '%cpaste' to avoid indentation errors if the option set
+  if exists('g:slimux_python_ipython')
+    return "%cpaste".a:text."--"
+
   "" Check if last line is empty in multiline selections
   let l:last_line_empty = match(a:text,'\n\W*\n$') 
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -215,8 +215,16 @@ function! s:Send(tmux_packet)
       endif
 
       let named_buffer = s:tmux_version >= '2.0' ? '-b Slimux' : ''
+      if exists('g:slimux_python_ipython')
+        call system(g:slimux_tmux_path . ' load-buffer ' . named_buffer . ' -', '%cpaste')
+        call system(g:slimux_tmux_path . ' paste-buffer ' . named_buffer . ' -t ' . target)
+      endif
       call system(g:slimux_tmux_path . ' load-buffer ' . named_buffer . ' -', text)
       call system(g:slimux_tmux_path . ' paste-buffer ' . named_buffer . ' -t ' . target)
+      if exists('g:slimux_python_ipython')
+        call system(g:slimux_tmux_path . ' load-buffer ' . named_buffer . ' -', '--')
+        call system(g:slimux_tmux_path . ' paste-buffer ' . named_buffer . ' -t ' . target)
+      endif
 
       if type == "code"
         call s:ExecFileTypeFn("SlimuxPost_", [target])


### PR DESCRIPTION
As reported in #63 , this plugin doesn't work and need to use `%cpaste` which is also used in [vim-slime](https://github.com/jpalardy/vim-slime/tree/master/ftplugin/python). 
I added an option to use it, so I'm happy if you check it.
