### PR TITLE
[python] fix sending lines to ipython

### DIFF
--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -1,6 +1,13 @@
 " These python keywords should not have extra newline at indentation level 0
 let w:slimux_python_allowed_indent0 = ["elif", "else", "except", "finally"]
 
+if !exists('g:slimux_python_use_ipython')
+    let g:slimux_python_use_ipython = 0
+endif
+
+if g:slimux_python_use_ipython == 1
+    let g:slimux_python_paste_options = "-p"
+endif
 
 function! SlimuxEscape_python(text)
   "" Check if last line is empty in multiline selections
@@ -53,12 +60,20 @@ function! SlimuxEscape_python(text)
       endfor
   endif
 
+  let l:result = join(l:processed_lines,"")
+
   "" Return the processed lines
   if !l:at_indent0 && l:last_line_empty >= 0
       " We ended at indentation and last line was empty
-      return join(l:processed_lines,"").""
-  else
-      return join(l:processed_lines,"").""
+      let l:result .= ""
+  elseif g:slimux_python_use_ipython && l:at_indent0 && l:last_line_empty < 0 && len(l:non_processed_lines) > 1
+      let l:result .= ""
   endif
+
+  return l:result
+endfunction
+
+function! SlimuxPost_python(target_pane)
+    call system("tmux send-keys -t " . a:target_pane . " Enter")
 endfunction
 

--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -215,8 +215,9 @@ function! s:Send(tmux_packet)
       endif
 
       let named_buffer = s:tmux_version >= '2.0' ? '-b Slimux' : ''
+      let paste_options = s:GetFileTypeOption('paste_options', '')
       call system(g:slimux_tmux_path . ' load-buffer ' . named_buffer . ' -', text)
-      call system(g:slimux_tmux_path . ' paste-buffer ' . named_buffer . ' -t ' . target)
+      call system(g:slimux_tmux_path . ' paste-buffer ' . named_buffer . ' -t ' . target . ' ' . paste_options)
 
       if type == "code"
         call s:ExecFileTypeFn("SlimuxPost_", [target])
@@ -253,6 +254,18 @@ function! s:ExecFileTypeFn(fn_name, args)
   return result
 endfunction
 
+" dynamically get option values.
+" Ex: GetFileTypeOption("paste_options", "default") will retrieve values for
+" g:slimux_python_paste_options if it is defined, otherwise return "default"
+function! s:GetFileTypeOption(opt_name, default)
+    let result = a:default
+    if exists("&filetype")
+        let option = "g:slimux_" . &filetype . "_" . a:opt_name
+        if exists(option)
+            let result = {option}
+    endif
+    return result
+endfunction
 
 " Thanks to http://vim.1045645.n5.nabble.com/Is-there-any-way-to-get-visual-selected-text-in-VIM-script-td1171241.html#a1171243
 function! s:GetVisual() range


### PR DESCRIPTION
In ipython >= 5, the autoindent feature is deprecated. Thus if we send
multiple lines directly to it, the indentation will go wild.
Notice that with ipyton >= 5, multiple line paste(via Ctrl-V or
Command-V) is well supported. This this commit try to utilize the `-p`
option of `tmux paste-buffer` which will use bracket paste mode.

Checkout here for more information: https://cirw.in/blog/bracketed-paste