### PR TITLE
Fix pane with double digit ID not showing in list

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -141,7 +141,7 @@ function! s:SelectPane(tmux_packet, ...)
         " Remove current pane from pane list
         let l:current_pane_id = system(g:slimux_tmux_path . ' display-message -p "\#{pane_id}"')
         let l:current_pane_id = substitute(l:current_pane_id, "\n", "", "g")
-        let l:command .= " | grep -E -v " . shellescape("^" . l:current_pane_id, 1)
+        let l:command .= " | grep -E -v " . shellescape("^" . l:current_pane_id . ":", 1)
     endif
 
     " Warn if no additional pane is found


### PR DESCRIPTION
This fixes a bug by which if the digit(s) of the current pane's ID (e.g. `%1`) correspond to the prefix digit(s) of the target's ID (e.g. `%14`), then the target pane will not be shown in the list, and therefore cannot be chosen, frustrating attempts to send text/keys to that target pane. 

Thanks for this excellent plug-in! 
