### PR TITLE
find the tmux path even when the shell is tcsh

### DIFF
--- a/plugin/slimux.vim
+++ b/plugin/slimux.vim
@@ -3,7 +3,7 @@
 " License: MIT. See LICENSE
 
 if !exists('g:slimux_tmux_path')
-    let g:slimux_tmux_path = substitute(system('command -v tmux'), '\n\+$', '', '')
+    let g:slimux_tmux_path = substitute(system('whereis tmux'), '^tmux: \(\S\+\) .*$', '\1', '')
 endif
 if $PREFERRED_TMUX != ''
     let g:tmux_preferred_cmd = ''


### PR DESCRIPTION
The shell command used to detect the path to the tmux executable is available in Bash but not Tcsh: `command -v`. So I proposed to use `whereis` instead, which should be available in both shells. However it's an external program, not a builtin, so I am not sure of its availability under all systems (I have Ubuntu 16.04).