### PR TITLE
added sml support, fixed '\n' bug in scheme and racket

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -66,7 +66,7 @@ endif
 function! SlimuxEscape_racket(text)
     " if text does not end with newline, add one
     if a:text !~ "\n$"
-        let str_ret = a:text . '\n'
+        let str_ret = a:text . "\n"
     else
         let str_ret = a:text
     endif

--- a/ftplugin/scheme.vim
+++ b/ftplugin/scheme.vim
@@ -53,7 +53,7 @@ endif
 function! SlimuxEscape_scheme(text)
     " if text does not end with newline, add one
     if a:text !~ "\n$"
-        let str_ret = a:text . '\n'
+        let str_ret = a:text . "\n"
     else
         let str_ret = a:text
     endif

--- a/ftplugin/sml.vim
+++ b/ftplugin/sml.vim
@@ -1,0 +1,19 @@
+
+if exists("g:slimux_sml_loaded")
+    finish
+endif
+let g:slimux_sml_loaded= 1
+
+function! SlimuxEscape_sml(text)
+    " if text does not end with newline, add one
+    if a:text !~ ";\n$"
+        "let str_ret = a:text . ";\n"
+        let str_ret = substitute(a:text,"\n$",";\n","")
+    else
+        let str_ret = a:text
+    endif
+
+    return str_ret
+endfunction
+
+


### PR DESCRIPTION
*Bug fix where scheme/racket was sending a literal '\n'

*smlnj feature which adds the optional semicolon to an expression if missing (otherwise the REPL won't evaluate it)